### PR TITLE
Strip trailing whitespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,5 +14,6 @@ BugReports: https://github.com/csgillespie/roxygen2Comment/issues
 Imports:
     rstudioapi(>= 0.5)
 Suggests: knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
+Encoding: UTF-8

--- a/R/roxygen2_block.R
+++ b/R/roxygen2_block.R
@@ -15,9 +15,19 @@ roxygen2_block = function() {
 
   # If roxygen2 block remove #'
   # If not remove, add #'
-  is_roxy2 = substr(line, 1L, 2L) == "#'"
+  comment = grep(
+    "^#'\\s?" # line starts with "#'", has no or one trailing whitespace
+    , line
+    , value = TRUE
+  )
+
+  is_roxy2 = length(comment > 0)
   if(is_roxy2) {
-    rng = Map(c, Map(c, r, 1), Map(c, r, 3))
+    rng = Map(
+      c
+      , Map(c, r, 1)
+      , Map(c, r, ifelse(grepl("\\s", comment), 4, 3)) # if applicable, strip trailing whitespace
+    )
     modifyRange(rng, "")
   } else {
     pos = Map(c, r_start:r_end, 1)

--- a/man/roxygen2_block.Rd
+++ b/man/roxygen2_block.Rd
@@ -9,4 +9,3 @@ roxygen2_block()
 \description{
 Adds an roxygen2 comment block
 }
-


### PR DESCRIPTION
Thanks for the wonderful add-in. I believe this PR could be a valuable extension to your code, see eg. #1. In its current form, up to one trailing whitespace following the **roxygen2** comment `#'` is stripped. Modifying the code in a way to strip away an arbitrary number of whitespaces should be straightforward.